### PR TITLE
Bugfix: nested closed brackets was causing a dash bug

### DIFF
--- a/src/printer.ts
+++ b/src/printer.ts
@@ -576,6 +576,9 @@ export class PugPrinter {
 			// There were no attributes
 			this.result = this.result.slice(0, -1);
 		} else if (this.previousToken?.type === 'attribute') {
+			if (!this.closingBracketRemainsAtNewLine) {
+				this.result = this.result.trimRight();
+			}
 			this.result += ')';
 		}
 		if (this.nextToken?.type === 'text' || this.nextToken?.type === 'path') {

--- a/test/options/closingBracketPosition/last-line/formatted.pug
+++ b/test/options/closingBracketPosition/last-line/formatted.pug
@@ -15,11 +15,16 @@ nav-component(locale-relative-redirect="true", highlight="home", pin="false")
   data-arr=[1, 2, 3, 4, 5, 6],
   data-obj={ att: 1, attr2: 2 })
 
-
 div
-  input(
+  .nested-div-1(
     type="text",
-    value="my_value",
-    name="my_name",
-    alt="my_alt",
+    value="my_value1",
+    name="my_name1",
+    alt="my_alt1",
     autocomplete="on")
+    .nested-div-2(
+      type="text",
+      value="my_value2",
+      name="my_name2",
+      alt="my_alt2",
+      autocomplete="on")

--- a/test/options/closingBracketPosition/last-line/unformatted.pug
+++ b/test/options/closingBracketPosition/last-line/unformatted.pug
@@ -7,10 +7,19 @@ nav-component(locale-relative-redirect="true", highlight="home", pin="false")
 .wrapper(data-nav=true data-next="Next" data-prev="Prev" data-slides=4 data-arr=[1,2,3,4,5,6] data-obj={att: 1, attr2: 2})
 
 div
-  input(
+  div(
+    class='nested-div-1'
     type="text",
-    value="my_value",
-    name="my_name",
-    alt="my_alt",
+    value="my_value1",
+    name="my_name1",
+    alt="my_alt1",
     autocomplete="on"
   )
+    div(
+      class='nested-div-2'
+      type="text",
+      value="my_value2",
+      name="my_name2",
+      alt="my_alt2",
+      autocomplete="on"
+    )


### PR DESCRIPTION
## What Changed?
- Each nesting was adding an empty space while `closingBracketPosition` equals to `last-line`
-  An improved test added.

## Related Issue
- #82 