### PR TITLE
Do not reformat interpolation attribute values

### DIFF
--- a/src/printer.ts
+++ b/src/printer.ts
@@ -56,7 +56,13 @@ import {
 	resolveClosingBracketPositionOption
 } from './options';
 import { isAngularAction, isAngularBinding, isAngularDirective, isAngularInterpolation } from './utils/angular';
-import { isQuoted, makeString, previousNormalAttributeToken, unwrapLineFeeds } from './utils/common';
+import {
+	isQuoted,
+	isMultilineInterpolation,
+	makeString,
+	previousNormalAttributeToken,
+	unwrapLineFeeds
+} from './utils/common';
 import { isVueEventBinding, isVueExpression } from './utils/vue';
 
 const logger: Logger = createLogger(console);
@@ -526,7 +532,9 @@ export class PugPrinter {
 			}
 		} else {
 			let val = token.val;
-			if (isVueExpression(token.name)) {
+			if (isMultilineInterpolation(val)) {
+				// do not reformat multiline strings surrounded by `
+			} else if (isVueExpression(token.name)) {
 				val = this.formatVueExpression(val);
 			} else if (isVueEventBinding(token.name)) {
 				val = this.formatVueEventBinding(val);

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -65,6 +65,10 @@ export function isQuoted(val: string): boolean {
 	return /^["'](.*)["']$/.test(val);
 }
 
+export function isMultilineInterpolation(val: string): boolean {
+	return /^`[\s\S]*`$/m.test(val) && val.includes('\n');
+}
+
 // Copy of https://github.com/prettier/prettier/blob/master/src/common/util.js#L647
 export function makeString(
 	rawContent: string,

--- a/test/issues/issue-80/formatted.pug
+++ b/test/issues/issue-80/formatted.pug
@@ -1,0 +1,19 @@
+div
+  span.aui-lozenge(
+    :class=`{
+      "aui-lozenge-inprogress": pipeline.status == PipelineStatus.Running,
+      "aui-lozenge-error":      pipeline.status == PipelineStatus.Failed
+    }`
+  )
+
+  span.aui-lozenge(
+    :class='[isActive ? "some-class-name" : "some-other-class-name"]'
+  )
+
+  span.aui-lozenge(
+    :class='[isActive ? "some-class-name" : "some-other-class-name"]'
+  )
+
+  span.aui-lozenge(
+    :class='[isActive ? "some-class-name" : "some-other-class-name"]'
+  )

--- a/test/issues/issue-80/issue-80.test.ts
+++ b/test/issues/issue-80/issue-80.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { format } from 'prettier';
+import { plugin } from './../../../src/index';
+
+describe('Issues', () => {
+	test('should not reformat multiline interpolation strings', () => {
+		const expected: string = readFileSync(resolve(__dirname, 'formatted.pug'), 'utf8');
+		const code: string = readFileSync(resolve(__dirname, 'unformatted.pug'), 'utf8');
+		const actual: string = format(code, {
+			parser: 'pug' as any,
+			plugins: [plugin],
+
+			semi: false,
+			singleQuote: true
+		});
+
+		expect(actual).toBe(expected);
+	});
+});

--- a/test/issues/issue-80/unformatted.pug
+++ b/test/issues/issue-80/unformatted.pug
@@ -1,0 +1,19 @@
+div
+  span.aui-lozenge(
+    :class=`{
+      "aui-lozenge-inprogress": pipeline.status == PipelineStatus.Running,
+      "aui-lozenge-error":      pipeline.status == PipelineStatus.Failed
+    }`
+  )
+
+  span.aui-lozenge(
+    :class=`[ isActive ? "some-class-name" : "some-other-class-name" ]`
+  )
+
+  span.aui-lozenge(
+    :class="[ isActive ? 'some-class-name' : 'some-other-class-name' ]"
+  )
+
+  span.aui-lozenge(
+    :class='[ isActive ? "some-class-name" : "some-other-class-name" ]'
+  )


### PR DESCRIPTION
Object literals are widely used in Vue.

For example, they can be used to assign set of classes conditionally:

```pug
span.aui-lozenge(
  :class=`{
    "aui-lozenge-inprogress": pipeline.status == PipelineStatus.Running,
    "aui-lozenge-error":      pipeline.status == PipelineStatus.Failed
  }`
)
```

This patch does not modify behavior regarding non-multiline strings.

Fixes #80.