### PR TITLE
Fix counting of current line-length

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ By using versions of these standard options prefixed with `pug`, you can overrid
   Print spaces between brackets in object literals.
 - `pugPrintWidth`  
   Specify the line length that the printer will wrap on.  
-  _Currently this is not very accurate, but works._
 - `pugSemi`  
   Print semicolons at the ends of code statements.
 - `pugSingleQuote`  

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -235,10 +235,9 @@ export class PugPrinter {
 	}
 
 	private tokenNeedsSeparator(token: AttributeToken): boolean {
-		return (
-			!this.neverUseAttributeSeparator &&
-			(this.alwaysUseAttributeSeparator || /^(\(|\[|:).*/.test(token.name))
-		);
+		return this.neverUseAttributeSeparator
+			? false
+			: this.alwaysUseAttributeSeparator || /^(\(|\[|:).*/.test(token.name);
 	}
 
 	private formatDelegatePrettier(
@@ -451,9 +450,8 @@ export class PugPrinter {
 						this.currentLineLength += tempToken.name.length;
 						if (hasNonPrefixAttributes) {
 							// This isn't the first non-prefix attribute, add a space and separator
+							this.currentLineLength += 1;
 							if (this.tokenNeedsSeparator(tempToken)) {
-								this.currentLineLength += 2;
-							} else {
 								this.currentLineLength += 1;
 							}
 						}

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -100,14 +100,10 @@ export class PugPrinter {
 	private result: string = '';
 
 	private currentIndex: number = 0;
+	private currentLineLength: number = 0;
 
 	private readonly indentString: string;
 	private indentLevel: number = 0;
-
-	/**
-	 * Counting the line length starts at 0
-	 */
-	private currentLineLength: number = 0;
 
 	private readonly quotes: "'" | '"';
 	private readonly otherQuotes: "'" | '"';
@@ -420,21 +416,24 @@ export class PugPrinter {
 			this.possibleClassPosition = this.result.length;
 			result = '(';
 			logger.debug(this.currentLineLength);
-			this.currentLineLength += 1;
 			let tempToken: AttributeToken | EndAttributesToken = this.nextToken;
 			let tempIndex: number = this.currentIndex + 1;
-			let hasPrefixAttribute: boolean = false;
-			let hasNonPrefixAttributes: boolean = false;
-			let numAttributes: number = 0;
+			// In pug, tags can have two kind of attributes: normal attributes that appear between parantheses,
+			// and literals for ids and classes, prefixing the paranthesis, e.g.: `#id.class(attribute="value")`
+			// https://pugjs.org/language/attributes.html#class-literal
+			// https://pugjs.org/language/attributes.html#id-literal
+			// In the stream of attribute tokens, distinguish those that can be converted to literals,
+			// and count those that cannot (normal attributes) to determine the resulting line length correctly.
+			let hasLiteralAttributes: boolean = false;
+			let numNormalAttributes: number = 0;
 			while (tempToken.type === 'attribute') {
-				numAttributes++;
 				if (!this.wrapAttributes && this.wrapAttributesPattern?.test(tempToken.name)) {
 					this.wrapAttributes = true;
 				}
 				switch (tempToken.name) {
 					case 'class':
 					case 'id': {
-						hasPrefixAttribute = true;
+						hasLiteralAttributes = true;
 						const val: string = tempToken.val.toString();
 						if (isQuoted(val)) {
 							this.currentLineLength -= 2;
@@ -448,8 +447,9 @@ export class PugPrinter {
 					}
 					default: {
 						this.currentLineLength += tempToken.name.length;
-						if (hasNonPrefixAttributes) {
-							// This isn't the first non-prefix attribute, add a space and separator
+						if (numNormalAttributes > 0) {
+							// This isn't the first normal attribute that will appear between parantheses,
+							// add space and separator
 							this.currentLineLength += 1;
 							if (this.tokenNeedsSeparator(tempToken)) {
 								this.currentLineLength += 1;
@@ -464,32 +464,29 @@ export class PugPrinter {
 							this.currentLineLength += 1 + val.length;
 							logger.debug({ tokenVal: val, length: val.length }, this.currentLineLength);
 						}
-						hasNonPrefixAttributes = true;
+						numNormalAttributes++;
 						break;
 					}
 				}
 				tempToken = this.tokens[++tempIndex] as AttributeToken | EndAttributesToken;
 			}
 			logger.debug('after token', this.currentLineLength);
-			if (hasPrefixAttribute) {
-				// Remove div
+			if (hasLiteralAttributes) {
+				// Remove div as it will be replaced with the literal for id and/or class
 				if (this.previousToken?.type === 'tag' && this.previousToken.val === 'div') {
 					this.currentLineLength -= 3;
 				}
 			}
-			if (hasNonPrefixAttributes) {
-				// Add trailing brace
-				this.currentLineLength += 1;
-			} else {
-				// Remove leading brace
-				this.currentLineLength -= 1;
+			if (numNormalAttributes > 0) {
+				// Add leading and trailing parantheses
+				this.currentLineLength += 2;
 			}
 			logger.debug(this.currentLineLength);
 			if (
 				!this.wrapAttributes &&
 				(this.currentLineLength > this.options.pugPrintWidth ||
 					(this.options.pugWrapAttributesThreshold >= 0 &&
-						numAttributes > this.options.pugWrapAttributesThreshold))
+						numNormalAttributes > this.options.pugWrapAttributesThreshold))
 			) {
 				this.wrapAttributes = true;
 			}

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -234,6 +234,13 @@ export class PugPrinter {
 		return !!token && possibilities.includes(token.type) !== invert;
 	}
 
+	private tokenNeedsSeparator(token: AttributeToken): boolean {
+		return (
+			!this.neverUseAttributeSeparator &&
+			(this.alwaysUseAttributeSeparator || /^(\(|\[|:).*/.test(token.name))
+		);
+	}
+
 	private formatDelegatePrettier(
 		val: string,
 		parser: '__vue_expression' | '__ng_binding' | '__ng_action' | '__ng_directive'
@@ -443,12 +450,10 @@ export class PugPrinter {
 					default: {
 						this.currentLineLength += tempToken.name.length;
 						if (hasNonPrefixAttributes) {
-							// If this isn't the first non-prefix attribute, add space and separator
-							this.currentLineLength += 1;
-							if (
-								!this.neverUseAttributeSeparator &&
-								(this.alwaysUseAttributeSeparator || /^(\(|\[|:).*/.test(tempToken.name))
-							) {
+							// This isn't the first non-prefix attribute, add a space and separator
+							if (this.tokenNeedsSeparator(tempToken)) {
+								this.currentLineLength += 2;
+							} else {
 								this.currentLineLength += 1;
 							}
 						}
@@ -590,10 +595,7 @@ export class PugPrinter {
 			this.currentIndex
 		);
 		if (this.previousToken?.type === 'attribute' && (!this.previousAttributeRemapped || hasNormalPreviousToken)) {
-			if (
-				!this.neverUseAttributeSeparator &&
-				(this.alwaysUseAttributeSeparator || /^(\(|\[|:).*/.test(token.name))
-			) {
+			if (this.tokenNeedsSeparator(token)) {
 				this.result += ',';
 			}
 			if (!this.wrapAttributes) {

--- a/tests/options/attributeSeparator/always/always.test.ts
+++ b/tests/options/attributeSeparator/always/always.test.ts
@@ -11,6 +11,7 @@ describe('Options', () => {
 			const actual: string = format(code, {
 				parser: 'pug' as any,
 				plugins: [plugin],
+				printWidth: 80,
 				// @ts-expect-error
 				attributeSeparator: 'always'
 			});

--- a/tests/options/attributeSeparator/always/always.test.ts
+++ b/tests/options/attributeSeparator/always/always.test.ts
@@ -11,6 +11,7 @@ describe('Options', () => {
 			const actual: string = format(code, {
 				parser: 'pug' as any,
 				plugins: [plugin],
+				// The `.length-test` elements are tested against a `printWidth` of 80 (currently also the default):
 				printWidth: 80,
 				// @ts-expect-error
 				attributeSeparator: 'always'

--- a/tests/options/attributeSeparator/always/formatted.pug
+++ b/tests/options/attributeSeparator/always/formatted.pug
@@ -1,3 +1,10 @@
+.length-test(attributes1="foo", :attribute2="bar", attribute3="filler.........")
+.length-test(
+  attributes1="foo",
+  :attribute2="bar",
+  attribute3="filler.........."
+)
+
 button(type="submit", (click)="play()", disabled)
 hello-framework(
   [name]="name",

--- a/tests/options/attributeSeparator/always/unformatted.pug
+++ b/tests/options/attributeSeparator/always/unformatted.pug
@@ -1,3 +1,6 @@
+.length-test(attributes1="foo", :attribute2="bar", attribute3="filler.........")
+.length-test(attributes1="foo", :attribute2="bar", attribute3="filler..........")
+
 button(type="submit", (click)="play()" disabled)
 hello-framework([name]="name", [version]="version", (release)="onVersionRelease()")
 

--- a/tests/options/attributeSeparator/as-needed/as-needed.test.ts
+++ b/tests/options/attributeSeparator/as-needed/as-needed.test.ts
@@ -11,6 +11,7 @@ describe('Options', () => {
 			const actual: string = format(code, {
 				parser: 'pug' as any,
 				plugins: [plugin],
+				// The `.length-test` elements are tested against a `printWidth` of 80 (currently also the default):
 				printWidth: 80,
 				// @ts-expect-error
 				attributeSeparator: 'as-needed'

--- a/tests/options/attributeSeparator/as-needed/as-needed.test.ts
+++ b/tests/options/attributeSeparator/as-needed/as-needed.test.ts
@@ -11,6 +11,7 @@ describe('Options', () => {
 			const actual: string = format(code, {
 				parser: 'pug' as any,
 				plugins: [plugin],
+				printWidth: 80,
 				// @ts-expect-error
 				attributeSeparator: 'as-needed'
 			});

--- a/tests/options/attributeSeparator/as-needed/formatted.pug
+++ b/tests/options/attributeSeparator/as-needed/formatted.pug
@@ -1,3 +1,10 @@
+.length-test(attributes1="foo", :attribute2="bar" attribute3="filler..........")
+.length-test(
+  attributes1="foo",
+  :attribute2="bar"
+  attribute3="filler..........."
+)
+
 button(type="submit", (click)="play()" disabled)
 hello-framework(
   [name]="name",

--- a/tests/options/attributeSeparator/as-needed/unformatted.pug
+++ b/tests/options/attributeSeparator/as-needed/unformatted.pug
@@ -1,3 +1,6 @@
+.length-test(attributes1="foo", :attribute2="bar" attribute3="filler..........")
+.length-test(attributes1="foo", :attribute2="bar" attribute3="filler...........")
+
 button(type="submit", (click)="play()", disabled)
 hello-framework([name]="name", [version]="version", (release)="onVersionRelease()")
 

--- a/tests/options/attributeSeparator/none/formatted.pug
+++ b/tests/options/attributeSeparator/none/formatted.pug
@@ -1,3 +1,10 @@
+.length-test(attributes1="foo" :attribute2="bar" attribute3="filler...........")
+.length-test(
+  attributes1="foo"
+  :attribute2="bar"
+  attribute3="filler............"
+)
+
 button(type="submit" :style="style" @click="play()" disabled)
 
 nav-component(locale-relative-redirect="true" highlight="home" pin="false")

--- a/tests/options/attributeSeparator/none/none.test.ts
+++ b/tests/options/attributeSeparator/none/none.test.ts
@@ -11,6 +11,8 @@ describe('Options', () => {
 			const actual: string = format(code, {
 				parser: 'pug' as any,
 				plugins: [plugin],
+				// The `.length-test` elements are tested against a `printWidth` of 80 (currently also the default):
+				printWidth: 80,
 				// @ts-expect-error
 				attributeSeparator: 'none'
 			});

--- a/tests/options/attributeSeparator/none/unformatted.pug
+++ b/tests/options/attributeSeparator/none/unformatted.pug
@@ -1,3 +1,6 @@
+.length-test(attributes1="foo" :attribute2="bar" attribute3="filler...........")
+.length-test(attributes1="foo" :attribute2="bar" attribute3="filler............")
+
 button(type="submit", :style="style", @click="play()", disabled)
 
 nav-component(locale-relative-redirect="true", highlight="home", pin="false")


### PR DESCRIPTION
I noticed that the current line-length wasn't counted correctly depending on the setting of attributeSeparator.  
This PR fixes that and adds tests for the various settings.
