### PR TITLE
Support prettier-ignore comments inside pug templates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,7 @@ max_line_length = off
 trim_trailing_whitespace = false
 indent_style = space
 indent_size = 2
+
+[*.pug]
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Please note that the [plugin ecosystem in Prettier](https://prettier.io/docs/en/
 
 Plugin for Prettier to format pug code
 
-You can disable code formatting for a particular code block by adding <nobr>`<!-- prettier-ignore -->`</nobr> before ` ```pug `.
+You can disable code formatting for a particular code block by adding <nobr>`<!-- prettier-ignore -->`</nobr> before ` ```pug `,
+as well as by using <nobr>`//- prettier-ignore`</nobr> comments inside your pug templates.
 
 ````markdown
 Pug code with custom formatting:

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ You can disable code formatting for a particular element by adding <nobr>`//- pr
 
 ```pug
 div.text( color =   "primary",  disabled  ="true"  )
-// -prettier-ignore
+//- prettier-ignore
 div.text( color =   "primary",  disabled  ="true"  )
-// -prettier-ignore
+//- prettier-ignore: because of reasons
 div
   div.text( color =   "primary",  disabled  ="true"  )
 ```
@@ -77,9 +77,9 @@ Prettified output:
 
 ```pug
 .text(color="primary", disabled)
-// -prettier-ignore
+//- prettier-ignore
 div.text( color =   "primary",  disabled  ="true"  )
-// -prettier-ignore
+//- prettier-ignore: because of reasons
 div
   div.text( color =   "primary",  disabled  ="true"  )
 ```

--- a/README.md
+++ b/README.md
@@ -33,24 +33,6 @@ Please note that the [plugin ecosystem in Prettier](https://prettier.io/docs/en/
 
 Plugin for Prettier to format pug code
 
-You can disable code formatting for a particular code block by adding <nobr>`<!-- prettier-ignore -->`</nobr> before ` ```pug `,
-as well as by using <nobr>`//- prettier-ignore`</nobr> comments inside your pug templates.
-
-````markdown
-Pug code with custom formatting:
-
-<!-- prettier-ignore -->
-```pug
-div.text( color =   "primary",  disabled  ="true"  )
-```
-
-Prettified code:
-
-```pug
-.text(color="primary", disabled)
-```
-````
-
 ## Getting started
 
 Simply install `prettier` and `@prettier/plugin-pug` as your project’s npm devDependencies:
@@ -77,6 +59,47 @@ yarn add --dev prettier @prettier/plugin-pug
 ## or
 yarn prettier --write "**/*.pug"
 ```
+
+### Selectively ignoring automatic formatting
+
+You can disable code formatting for a particular element by adding <nobr>`//- prettier-ignore`</nobr> comments in your pug templates:
+
+```pug
+div.text( color =   "primary",  disabled  ="true"  )
+// -prettier-ignore
+div.text( color =   "primary",  disabled  ="true"  )
+// -prettier-ignore
+div
+  div.text( color =   "primary",  disabled  ="true"  )
+```
+
+Prettified output:
+
+```pug
+.text(color="primary", disabled)
+// -prettier-ignore
+div.text( color =   "primary",  disabled  ="true"  )
+// -prettier-ignore
+div
+  div.text( color =   "primary",  disabled  ="true"  )
+```
+
+You can also disable code formatting in Markdown for a particular ` ```pug ` block by adding <nobr>`<!-- prettier-ignore -->`</nobr> before the block:
+
+````markdown
+Pug code with preserved custom formatting:
+
+<!-- prettier-ignore -->
+```pug
+div.text( color =   "primary",  disabled  ="true"  )
+```
+
+Pug code with automatic formatting:
+
+```pug
+.text(color="primary", disabled)
+```
+````
 
 ### Pug versions of standard prettier options
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,8 @@ if (process.env.NODE_ENV === 'test') {
 }
 
 type FastPathStackEntry = {
-	content: string,
-	tokens: Token[]
+	content: string;
+	tokens: Token[];
 };
 
 export const plugin: Plugin = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,11 @@ if (process.env.NODE_ENV === 'test') {
 	logger.setLogLevel(LogLevel.DEBUG);
 }
 
+type FastPathStackEntry = {
+	content: string,
+	tokens: Token[]
+};
+
 export const plugin: Plugin = {
 	languages: [
 		{
@@ -38,13 +43,14 @@ export const plugin: Plugin = {
 	],
 	parsers: {
 		pug: {
-			parse(text: string, parsers: { [parserName: string]: Parser }, options: ParserOptions): Token[] {
+			parse(text: string, parsers: { [parserName: string]: Parser }, options: ParserOptions): FastPathStackEntry {
 				logger.debug('[parsers:pug:parse]:', { text });
-				const tokens: lex.Token[] = lex(text.trimLeft());
+				const content: string = text.trimLeft();
+				const tokens: lex.Token[] = lex(content);
 				// logger.debug('[parsers:pug:parse]: tokens', JSON.stringify(tokens, undefined, 2));
 				// const ast: AST = parse(tokens, {});
 				// logger.debug('[parsers:pug:parse]: ast', JSON.stringify(ast, undefined, 2));
-				return tokens;
+				return { content, tokens };
 			},
 			astFormat: 'pug-ast',
 			hasPragma(text: string): boolean {
@@ -67,9 +73,10 @@ export const plugin: Plugin = {
 	printers: {
 		'pug-ast': {
 			print(path: FastPath, options: ParserOptions & PugParserOptions, print: (path: FastPath) => Doc): Doc {
-				const tokens: Token[] = path.stack[0];
+				const entry: FastPathStackEntry = path.stack[0];
+				const { content, tokens } = entry;
 				const pugOptions: PugPrinterOptions = convergeOptions(options);
-				const printer: PugPrinter = new PugPrinter(tokens, pugOptions);
+				const printer: PugPrinter = new PugPrinter(content, tokens, pugOptions);
 				const result: string = printer.build();
 				logger.debug('[printers:pug-ast:print]:', result);
 				return result;

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -771,7 +771,7 @@ export class PugPrinter {
 
 	private comment(commentToken: CommentToken): string {
 		let result: string = this.computedIndent;
-		if (commentToken.val.trim() === 'prettier-ignore') {
+		if (/^\s*prettier-ignore\b/.test(commentToken.val)) {
 			// Use a own token processing loop to find the end of the stream of tokens to be ignored by formatting,
 			// and uses their `loc` properties to retrieve the original pug code to be used instead.
 			let token: Token | null = this.getNextToken();

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -129,7 +129,7 @@ export class PugPrinter {
 	private pipelessComment: boolean = false;
 
 	public constructor(
-		private content: string,
+		private readonly content: string,
 		private tokens: Token[],
 		private readonly options: PugPrinterOptions
 	) {
@@ -203,12 +203,12 @@ export class PugPrinter {
 					token.type === 'comment' &&
 					token.val.trim() === 'prettier-ignore'
 				) {
-					// Use a spearate token processing loop that finds the end of the tokens to be ignored by formatting,
-					// and uses their `loc` properties to retreive the original pug code to be used instead.
-					const firstToken = this.tokens[index];
-					const startsWithNewLine = firstToken.type === 'newline';
-					let skipNewline = startsWithNewLine;
-					let ignoreLevel = 0;
+					// Use a separate token processing loop that finds the end of the tokens to be ignored by formatting,
+					// and uses their `loc` properties to retrieve the original pug code to be used instead.
+					const firstToken: Token = this.tokens[index];
+					const startsWithNewLine: boolean = firstToken.type === 'newline';
+					let skipNewline: boolean = startsWithNewLine;
+					let ignoreLevel: number = 0;
 					while (index < this.tokens.length) {
 						token = this.tokens[index++];
 						const { type } = token;
@@ -228,14 +228,14 @@ export class PugPrinter {
 							}
 						}
 					}
-					const lastToken = this.tokens[index - 1];
-					const lines = this.getUnformattedContentLines(firstToken, lastToken);
+					const lastToken: Token = this.tokens[index - 1];
+					const lines: string[] = this.getUnformattedContentLines(firstToken, lastToken);
 					// Start with an empty string for the first newline after comment.
 					if (startsWithNewLine) {
 						lines.unshift('');
 					}
 					// Trim the last line, since indentation of formatted pug is handled separately.
-					const lastLine = lines.pop();
+					const lastLine: string | undefined = lines.pop();
 					if (lastLine !== undefined) {
 						lines.push(lastLine.trimRight());
 					}
@@ -286,12 +286,12 @@ export class PugPrinter {
 	private getUnformattedContentLines(firstToken: Token, lastToken: Token): string[] {
 		const { start } = firstToken.loc;
 		const { end } = lastToken.loc;
-		const lines = this.content.split(/\r\n|\n|\r/);
-		const startLine = start.line - 1;
-		const endLine = end.line - 1;
+		const lines: string[] = this.content.split(/\r\n|\n|\r/);
+		const startLine: number = start.line - 1;
+		const endLine: number = end.line - 1;
 		const parts: string[] = [];
 		parts.push(lines[startLine].substring(start.column - 1));
-		for (let line = startLine + 1; line < endLine; line++) {
+		for (let line: number = startLine + 1; line < endLine; line++) {
 			parts.push(lines[line]);
 		}
 		parts.push(lines[endLine].substring(0, end.column - 1));

--- a/tests/prettier-ignore/formatted.pug
+++ b/tests/prettier-ignore/formatted.pug
@@ -11,7 +11,7 @@ div
     :attribute2="bar",
     attribute3="something too long to keep on one line"
   )
-  //- prettier-ignore
+  //- prettier-ignore (because reasons)
   div
     .wrapper-4(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
 .wrapper-5(

--- a/tests/prettier-ignore/formatted.pug
+++ b/tests/prettier-ignore/formatted.pug
@@ -5,17 +5,27 @@ div
     attribute3="something too long to keep on one line"
   )
   //- prettier-ignore
-  .wrapper-2(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
-  .wrapper-3(
-    attributes1="foo",
-    :attribute2="bar",
-    attribute3="something too long to keep on one line"
-  )
-  //- prettier-ignore (because reasons)
   div
-    .wrapper-4(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
-.wrapper-5(
-  attributes1="foo",
-  :attribute2="bar",
-  attribute3="something too long to keep on one line"
-)
+    .wrapper-2(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
+    //- prettier-ignore: this is already ignored be the previous statement above
+    div
+      .wrapper-3(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
+  div
+    .wrapper-4(
+      attributes1="foo",
+      :attribute2="bar",
+      attribute3="something too long to keep on one line"
+    )
+    div
+      .wrapper-5(
+        attributes1="foo",
+        :attribute2="bar",
+        attribute3="something too long to keep on one line"
+      )
+    //- prettier-ignore
+    div
+      .wrapper-6(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
+      //- prettier-ignore: this is already ignored be the previous statement above
+      div
+        .wrapper-7(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
+  div

--- a/tests/prettier-ignore/formatted.pug
+++ b/tests/prettier-ignore/formatted.pug
@@ -1,0 +1,21 @@
+div
+  .wrapper-1(
+    attributes1="foo",
+    :attribute2="bar",
+    attribute3="something too long to keep on one line"
+  )
+  //- prettier-ignore
+  .wrapper-2(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
+  .wrapper-3(
+    attributes1="foo",
+    :attribute2="bar",
+    attribute3="something too long to keep on one line"
+  )
+  //- prettier-ignore
+  div
+    .wrapper-4(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
+.wrapper-5(
+  attributes1="foo",
+  :attribute2="bar",
+  attribute3="something too long to keep on one line"
+)

--- a/tests/prettier-ignore/prettier-ignore.test.ts
+++ b/tests/prettier-ignore/prettier-ignore.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { format } from 'prettier';
+import { plugin } from './../../src/index';
+
+describe('prettier-ignore', () => {
+	test('should handle // prettier-ignore statements', () => {
+		const expected: string = readFileSync(resolve(__dirname, 'formatted.pug'), 'utf8');
+		const code: string = readFileSync(resolve(__dirname, 'unformatted.pug'), 'utf8');
+		const actual: string = format(code, { parser: 'pug' as any, plugins: [plugin] });
+
+		expect(actual).toBe(expected);
+	});
+});

--- a/tests/prettier-ignore/unformatted.pug
+++ b/tests/prettier-ignore/unformatted.pug
@@ -1,9 +1,19 @@
 div
   .wrapper-1(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
   //- prettier-ignore
-  .wrapper-2(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
-  .wrapper-3(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
-  //- prettier-ignore (because reasons)
+  div
+    .wrapper-2(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
+    //- prettier-ignore: this is already ignored be the previous statement above
+    div
+      .wrapper-3(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
   div
     .wrapper-4(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
-.wrapper-5(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
+    div
+      .wrapper-5(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
+    //- prettier-ignore
+    div
+      .wrapper-6(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
+      //- prettier-ignore: this is already ignored be the previous statement above
+      div
+        .wrapper-7(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
+  div

--- a/tests/prettier-ignore/unformatted.pug
+++ b/tests/prettier-ignore/unformatted.pug
@@ -3,7 +3,7 @@ div
   //- prettier-ignore
   .wrapper-2(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
   .wrapper-3(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
-  //- prettier-ignore
+  //- prettier-ignore (because reasons)
   div
     .wrapper-4(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
 .wrapper-5(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")

--- a/tests/prettier-ignore/unformatted.pug
+++ b/tests/prettier-ignore/unformatted.pug
@@ -1,0 +1,9 @@
+div
+  .wrapper-1(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
+  //- prettier-ignore
+  .wrapper-2(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
+  .wrapper-3(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
+  //- prettier-ignore
+  div
+    .wrapper-4(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")
+.wrapper-5(attributes1="foo" :attribute2="bar"  attribute3   =   "something too long to keep on one line")


### PR DESCRIPTION
Use `//- prettier-ignore` comments to prevent automatic formatting of the following line or block:
```pug
div
  .wrapper-1(attributes1="foo", :attribute2="bar", attribute3="something too long to keep on one line")
  //- prettier-ignore
  .wrapper-2(attributes1="foo", :attribute2="bar", attribute3="something too long to keep on one line")
  .wrapper-3(attributes1="foo", :attribute2="bar", attribute3="something too long to keep on one line")
  //- prettier-ignore
  div
    .wrapper-4(attributes1="foo", :attribute2="bar", attribute3="something too long to keep on one line")
.wrapper-5(attributes1="foo", :attribute2="bar", attribute3="something too long to keep on one line")
```
->
```pug
div
  .wrapper-1(
    attributes1="foo",
    :attribute2="bar",
    attribute3="something too long to keep on one line"
  )
  //- prettier-ignore
  .wrapper-2(attributes1="foo", :attribute2="bar", attribute3="something too long to keep on one line")
  .wrapper-3(
    attributes1="foo",
    :attribute2="bar",
    attribute3="something too long to keep on one line"
  )
  //- prettier-ignore
  div
    .wrapper-4(attributes1="foo", :attribute2="bar", attribute3="something too long to keep on one line")
.wrapper-5(
  attributes1="foo",
  :attribute2="bar",
  attribute3="something too long to keep on one line"
)
```