### PR TITLE
Handle non-JS script content

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -94,6 +94,7 @@ module.exports = defineConfig({
 					'coffeescript',
 					'colno',
 					'doctype',
+					'ecmascript',
 					'endregion',
 					'eos',
 					'fallthrough',
@@ -133,7 +134,8 @@ module.exports = defineConfig({
 					'vue',
 					'vuepress',
 					'whitespace',
-					'xml'
+					'xml',
+					'yaml'
 				]
 			}
 		],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
 		"autocloseable",
 		"blockcode",
 		"codemirror",
+		"ecmascript",
 		"endregion",
 		"frameset",
 		"lehni",
@@ -24,7 +25,8 @@
 		"rvalue",
 		"typeof",
 		"vite",
-		"vuepress"
+		"vuepress",
+		"yaml"
 	],
 	"eslint.validate": ["javascript", "typescript"],
 	"typescript.tsdk": "node_modules/typescript/lib"

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -82,8 +82,10 @@ import {
 	makeString,
 	previousNormalAttributeToken,
 	previousTagToken,
+	previousTypeAttributeToken,
 	unwrapLineFeeds
 } from './utils/common';
+import { getScriptParserName } from './utils/script-mime-types';
 import { isSvelteInterpolation } from './utils/svelte';
 import {
 	isVueEventBinding,
@@ -1281,7 +1283,7 @@ export class PugPrinter {
 			let parser: BuiltInParserName | undefined;
 			switch (lastTagToken?.val) {
 				case 'script':
-					parser = 'babel';
+					parser = getScriptParserName(previousTypeAttributeToken(this.tokens, this.currentIndex));
 					break;
 				case 'style':
 					parser = 'css';

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -45,6 +45,28 @@ export function previousNormalAttributeToken(tokens: ReadonlyArray<Token>, index
 }
 
 /**
+ * Returns the previous type attribute token or undefined if no attribute is present.
+ *
+ * @param tokens A reference to the whole token array.
+ * @param index The current index on which the cursor is in the token array.
+ * @returns Previous attribute token if there was one.
+ */
+export function previousTypeAttributeToken(tokens: ReadonlyArray<Token>, index: number): AttributeToken | undefined {
+	for (let i: number = index - 1; i > 0; i--) {
+		const token: Token | undefined = tokens[i];
+		if (!token || token.type === 'start-attributes') {
+			return;
+		}
+		if (token.type === 'attribute') {
+			if (token.name === 'type') {
+				return token;
+			}
+		}
+	}
+	return;
+}
+
+/**
  * Unwraps line feeds from a given value.
  *
  * @param value The value to unwrap.

--- a/src/utils/script-mime-types.ts
+++ b/src/utils/script-mime-types.ts
@@ -1,0 +1,54 @@
+import { BuiltInParserName } from 'prettier';
+import { AttributeToken } from 'pug-lexer';
+
+// NOTE: XML would be useful, but it's not a default parser.
+//       YAML is not official, but it costs nothing to support it right now.
+const jsonSuffixRe: RegExp = /\+(json|yaml)$/i;
+const wrappingQuotesRe: RegExp = /(^("|'|`))|(("|'|`)$)/g;
+
+// Matches IANA media types to the required parser for them
+// https://iana.org/assignments/media-types/media-types.xhtml
+// Note: Don't need to put any suffixed types (+json, +xml) in here as it
+//       will be handled separately
+const scriptTypeToParserMap: Map<string, BuiltInParserName> = new Map([
+	['application/ecmascript', 'babel'],
+	['application/javascript', 'babel'],
+	['application/json', 'json'],
+	['text/ecmascript', 'babel'],
+	['text/javascript', 'babel'],
+	['text/markdown', 'markdown'],
+	['text/typescript', 'typescript']
+]);
+
+/**
+ * Decides which parser to format script contents with.
+ *
+ * @param typeAttrToken Type token of the.
+ * @returns Parser name to parse contents with.
+ */
+export function getScriptParserName(typeAttrToken?: AttributeToken): BuiltInParserName | undefined {
+	// Omission means Javascript
+	if (!typeAttrToken) {
+		return 'babel';
+	}
+
+	const typeRaw: string | boolean = typeAttrToken.val;
+	// If it's not a string, best not do anything
+	if ('string' !== typeof typeRaw) {
+		return;
+	}
+
+	const type: string = typeRaw.replace(wrappingQuotesRe, '');
+
+	// Empty type is equivalent to omission
+	if (!type) {
+		return 'babel';
+	}
+
+	const suffixExec: RegExpExecArray | null = jsonSuffixRe.exec(type);
+	if (suffixExec) {
+		return suffixExec[1] as unknown as 'json' | 'yaml';
+	}
+
+	return scriptTypeToParserMap.get(type);
+}

--- a/tests/syntax-errors/scripts-with-non-js-contents.pug
+++ b/tests/syntax-errors/scripts-with-non-js-contents.pug
@@ -1,0 +1,151 @@
+// Copied from JSON-LD playground
+script(
+  type='application/ld+json'
+).
+  {
+    "@context": {
+      "name": "http://schema.org/name",
+      "description": "http://schema.org/description",
+      "image": {
+        "@id": "http://schema.org/image",
+        "@type": "@id"
+      },
+      "geo": "http://schema.org/geo",
+      "latitude": {
+        "@id": "http://schema.org/latitude",
+        "@type": "xsd:float"
+      },
+      "longitude": {
+        "@id": "http://schema.org/longitude",
+        "@type": "xsd:float"
+      },
+      "xsd": "http://www.w3.org/2001/XMLSchema#"
+    },
+    "name": "The Empire State Building",
+    "description": "The Empire State Building is a 102-story landmark in New York City.",
+    "image": "http://www.civil.usherbrooke.ca/cours/gci215a/empire-state-building.jpg",
+    "geo": {
+      "latitude": "40.75",
+      "longitude": "73.98"
+    }
+  }
+
+// Copied from https://YAML.org
+script(
+  type='application/x-not-a-real+yaml'
+).
+  %YAML 1.2
+  ---
+  YAML: YAML Ain't Markup Language
+
+  What It Is: YAML is a human friendly data serialization
+    standard for all programming languages.
+
+  YAML Resources:
+    YAML 1.2 (3rd Edition): http://yaml.org/spec/1.2/spec.html
+    YAML 1.1 (2nd Edition): http://yaml.org/spec/1.1/
+    YAML 1.0 (1st Edition): http://yaml.org/spec/1.0/
+    YAML Issues Page:       https://github.com/yaml/yaml/issues
+    YAML Mailing List:      yaml-core@lists.sourceforge.net
+    YAML IRC Channel:       "#yaml on irc.libera.chat"
+    YAML Reference Parser:  http://ben-kiki.org/ypaste/
+    YAML Spec:              https://github.com/yaml/yaml-spec
+    YAML Test Suite:        https://github.com/yaml/yaml-test-suite
+    YAML Test Matrix:       https://matrix.yaml.io/
+    YAML Docker Runtimes:   https://github.com/yaml/yaml-runtimes
+    YAML Cookbook (Ruby):   YAML_for_ruby.html 
+
+  Projects:
+    C/C++:
+    - libfyaml           # "C" YAML 1.2 processor                                            | YTS
+    - libyaml            # "C" Fast YAML 1.1                                                 | YTS
+    - libcyaml           # YAML de/serialization of C data structures (using libyaml)
+    - yaml-cpp           # C++ YAML 1.2 implementation
+    Crystal:
+    - YAML               # YAML 1.1 from the standard library
+    C#/.NET:
+    - YamlDotNet         # YAML 1.1/(1.2) library with serialization support                 | YTS
+    - yaml-net           # YAML 1.1 library
+    D:
+    - D-YAML             # YAML 1.1 de/serialization library with official community support | YTS
+    Dart:
+    - yaml               # YAML package for Dart
+    Delphi:
+    - Neslib.Yaml        # YAML 1.1 Delphi binding to libyaml                                | YTS
+    Golang:
+    - Go-yaml            # YAML support for the Go language.
+    - Go-gypsy           # Simplified YAML parser written in Go.
+    - goccy/go-yaml      # YAML 1.2 implementation in pure Go.
+    Haskell:
+    - HsYAML             # YAML 1.2 implementation in pure Haskell                           | YTS
+    - YamlReference      # Haskell 1.2 reference parser
+    - yaml               # YAML 1.1 parser/renderer for Haskell (based on libyaml)
+    Java:
+    - SnakeYAML          # Java 5 / YAML 1.1
+    - YamlBeans          # To/from JavaBeans. YAML 1.0/1.1
+    - eo-yaml            # YAML 1.2 for Java 8. Also packaged as a Module (Java 9+).
+    JavaScript:
+    - js-yaml            # Native PyYAML port to JavaScript. Demo
+    - yaml               # JavaScript parser and stringifier (YAML 1.2, 1.1)                 | YTS
+    Nim:
+    - NimYAML            # YAML 1.2 implementation in pure Nim                               | YTS
+    OCaml:
+    - ocaml-syck         # YAML 1.0 via syck bindings
+    Perl Modules:
+    - YAML               # Pure Perl YAML 1.0 Module
+    - YAML::XS           # Binding to libyaml
+    - YAML::Syck         # Binding to libsyck
+    - YAML::Tiny         # A small YAML subset module
+    - YAML::PP           # A YAML 1.2/1.1 processor                                          | YTS
+    PHP:
+    - The Yaml Component # Symfony Yaml Component - Loads and dumps YAML files (YAML 1.2)  
+    - php-yaml           # libyaml bindings (YAML 1.1)
+    - syck               # syck bindings (YAML 1.0)
+    - spyc               # yaml loader/dumper (YAML 1.?)
+    Python:
+    - PyYAML             # YAML 1.1, pure python and libyaml binding
+    - ruamel.yaml        # YAML 1.2, update of PyYAML with round-tripping of comments
+    - PySyck             # YAML 1.0, syck binding
+    - strictyaml         # Restricted YAML subset
+    R:
+    - R YAML             # libyaml wrapper  
+    Ruby:
+    - psych              # libyaml wrapper (in Ruby core for 1.9.2)
+    - RbYaml             # YAML 1.1 (PyYAML Port)
+    - yaml4r             # YAML 1.0, standard library syck binding
+    Rust:
+    - yaml-rust          # YAML 1.2 implementation in pure Rust
+    - serde-yaml         # YAML de/serialization of structs
+    Others:
+    - yamlvim (src)      # YAML dumper/emitter in pure vimscript
+
+script(
+  type='text/typescript'
+).
+  const myVariable: string = 'Hello World' as any as string
+
+  function myFunc<myGeneric>({ myProp = 42 }: { myProp: number }): myGeneric {
+    console.log(myVariable)
+    return true
+  }
+
+  myFunc({ myProp: 100 })
+
+script(
+  type='text/markdown'
+).
+  # h1
+  ## h2
+  ### h3
+  #### h4
+  ##### h5
+  ###### h6
+
+  Hello World.
+
+  * Bullet point 1
+  * Bullet point 2
+
+  1. List item
+  2. Another list item
+  

--- a/tests/syntax-errors/syntax-errors.test.ts
+++ b/tests/syntax-errors/syntax-errors.test.ts
@@ -16,4 +16,10 @@ describe('Syntax-Errors', () => {
 			format(code, { parser: 'pug', plugins: [plugin] });
 		}).toThrow();
 	});
+	test('should format non-JS script without syntax error', () => {
+		const code: string = readFileSync(resolve(__dirname, 'scripts-with-non-js-contents.pug'), 'utf8');
+		expect(() => {
+			format(code, { parser: 'pug', plugins: [plugin] });
+		}).not.toThrow();
+	});
 });


### PR DESCRIPTION
@Shinigami92 I ended up doing most this before you PR'd. Take what you like from it or close it.

To add the I collated all the current IANA types in a single file: [media-types.txt](https://github.com/prettier/plugin-pug/files/6759064/media-types.txt) from the official [IANA reference](https://www.iana.org/assignments/media-types/media-types.xhtml). But most of them are not textual so have nothing to do with `<script>` tags. I've tried to find some sort of reference collating what people use the `type` attribute. Apart from refs to the old `language` attribute and VBScript, JScript and TCL and these aren't worth supporting.

