### PR TITLE
Fix corrupt attribute values on dynamically bound Vue props without quotes

### DIFF
--- a/src/printer.ts
+++ b/src/printer.ts
@@ -573,7 +573,9 @@ export class PugPrinter {
 		{ trimTrailingSemicolon = false }: FormatDelegatePrettierOptions = {}
 	): string {
 		val = val.trim();
-		val = val.slice(1, -1); // Remove quotes
+		if (isQuoted(val)) {
+			val = val.slice(1, -1); // Remove quotes
+		}
 		val = format(val, { parser, ...this.codeInterpolationOptions });
 		val = unwrapLineFeeds(val);
 		if (trimTrailingSemicolon && val[val.length - 1] === ';') {

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -573,7 +573,8 @@ export class PugPrinter {
 		{ trimTrailingSemicolon = false }: FormatDelegatePrettierOptions = {}
 	): string {
 		val = val.trim();
-		if (isQuoted(val)) {
+		const wasQuoted: boolean = isQuoted(val);
+		if (wasQuoted) {
 			val = val.slice(1, -1); // Remove quotes
 		}
 		val = format(val, { parser, ...this.codeInterpolationOptions });
@@ -581,7 +582,7 @@ export class PugPrinter {
 		if (trimTrailingSemicolon && val[val.length - 1] === ';') {
 			val = val.slice(0, -1);
 		}
-		return this.quoteString(val);
+		return wasQuoted ? this.quoteString(val) : val;
 	}
 
 	private formatStyleAttribute(val: string): string {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -165,7 +165,7 @@ export function isWrappedWith(val: string, start: string, end: string, offset: n
  * @returns Whether the value is quoted or not.
  */
 export function isQuoted(val: string): boolean {
-	if (/^(["'])(.*)\1$/.test(val)) {
+	if (/^(["'`])(.*)\1$/.test(val)) {
 		// Regex for checking if there are any unescaped quotations.
 		const regex: RegExp = new RegExp(`${val[0]}(?<!\\\\${val[0]})`);
 		return !regex.test(val.slice(1, -1));

--- a/tests/issues/issue-250/formatted.pug
+++ b/tests/issues/issue-250/formatted.pug
@@ -1,7 +1,9 @@
+- const circleSize = 72;
+- const circleWidth = 7;
 div
   v-progress-circular(
     :color="getProgressColor(currentCapacity)",
-    :size="circleSize",
+    :size=circleSize,
     :value="capacityPercentage",
-    :width="circleWidth"
+    :width=circleWidth
   ) {{ currentCapacity }}/{{ maxCapacity }}

--- a/tests/issues/issue-250/formatted.pug
+++ b/tests/issues/issue-250/formatted.pug
@@ -1,0 +1,7 @@
+div
+  v-progress-circular(
+    :color="getProgressColor(currentCapacity)",
+    :size="circleSize",
+    :value="capacityPercentage",
+    :width="circleWidth"
+  ) {{ currentCapacity }}/{{ maxCapacity }}

--- a/tests/issues/issue-250/issue-250.test.ts
+++ b/tests/issues/issue-250/issue-250.test.ts
@@ -4,7 +4,7 @@ import { format } from 'prettier';
 import { plugin } from './../../../src/index';
 
 describe('Issues', () => {
-	test('should handle spread destructuring in Vue syntax', () => {
+	test('should not quote pug variables assigned to Vue props', () => {
 		const expected: string = readFileSync(resolve(__dirname, 'formatted.pug'), 'utf8');
 		const code: string = readFileSync(resolve(__dirname, 'unformatted.pug'), 'utf8');
 		const actual: string = format(code, { parser: 'pug', plugins: [plugin] });

--- a/tests/issues/issue-250/issue-250.test.ts
+++ b/tests/issues/issue-250/issue-250.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { format } from 'prettier';
+import { plugin } from './../../../src/index';
+
+describe('Issues', () => {
+	test('should handle spread destructuring in Vue syntax', () => {
+		const expected: string = readFileSync(resolve(__dirname, 'formatted.pug'), 'utf8');
+		const code: string = readFileSync(resolve(__dirname, 'unformatted.pug'), 'utf8');
+		const actual: string = format(code, { parser: 'pug', plugins: [plugin] });
+
+		expect(actual).toBe(expected);
+	});
+});

--- a/tests/issues/issue-250/unformatted.pug
+++ b/tests/issues/issue-250/unformatted.pug
@@ -1,0 +1,7 @@
+div
+  v-progress-circular(
+    :color="getProgressColor(currentCapacity)",
+    :size=circleSize,
+    :value='capacityPercentage',
+    :width=circleWidth,
+  ) {{ currentCapacity }}/{{ maxCapacity }}

--- a/tests/issues/issue-250/unformatted.pug
+++ b/tests/issues/issue-250/unformatted.pug
@@ -1,3 +1,5 @@
+- const circleSize = 72;
+- const circleWidth = 7;
 div
   v-progress-circular(
     :color="getProgressColor(currentCapacity)",

--- a/tests/issues/issue-61/formatted.pug
+++ b/tests/issues/issue-61/formatted.pug
@@ -11,3 +11,8 @@ div
           a(
             [href]='Nav.currentProject().repo(getRepository(pipeline).slug).buildNoContext()'
           )
+          - const interpolation = "code"
+          //- Vue
+          a(:href=`interpolated-${interpolation}`)
+          //- Angular
+          a([href]=`interpolated-${interpolation}`)

--- a/tests/issues/issue-61/unformatted.pug
+++ b/tests/issues/issue-61/unformatted.pug
@@ -7,3 +7,8 @@ div
           a(:href=`Nav.currentProject().repo(getRepository(pipeline).slug).buildNoContext()`)
           //- Angular
           a([href]=`Nav.currentProject().repo(getRepository(pipeline).slug).buildNoContext()`)
+          - const interpolation = 'code'
+          //- Vue
+          a(:href=`interpolated-${interpolation}`)
+          //- Angular
+          a([href]=`interpolated-${interpolation}`)

--- a/tests/issues/issue-80/formatted.pug
+++ b/tests/issues/issue-80/formatted.pug
@@ -17,3 +17,8 @@ div
   span.aui-lozenge(
     :class='[isActive ? "some-class-name" : "some-other-class-name"]'
   )
+
+  - const interpolation = "some-class-name"
+  span.aui-lozenge(
+    :class=`[ isActive ? ${interpolation} : "some-other-class-name" ]`
+  )

--- a/tests/issues/issue-80/unformatted.pug
+++ b/tests/issues/issue-80/unformatted.pug
@@ -17,3 +17,8 @@ div
   span.aui-lozenge(
     :class='[ isActive ? "some-class-name" : "some-other-class-name" ]'
   )
+
+  - const interpolation = "some-class-name"
+  span.aui-lozenge(
+    :class=`[ isActive ? ${interpolation} : "some-other-class-name" ]`
+  )


### PR DESCRIPTION
# Changes:
- First commit adds a unit test to expose issue #250.
- Second commit changes code so that new test passes and all other test still pass (checks for quotes before stripping them).

Note that I changed `isQuoted` and added the back-tic quote to the test with the other two quote styles (was `"'`, now is ``"`'``). All the tests pass, running this on my code based produced correct results, but I only have plain and Vue-based code (no angular, react, svelte, etc..).  I looked at all the calling sites of `isQuoted` and it looks okay to me, but someone more familiar with the code base should probably review that carefully.


