### PR TITLE
Add `funding` key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,16 @@
     "type": "git",
     "url": "https://github.com/prettier/plugin-pug.git"
   },
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/Shinigami92"
+    },
+    {
+      "type": "paypal",
+      "url": "https://www.paypal.com/donate/?hosted_button_id=L7GY729FBKTZY"
+    }
+  ],
   "bugs": "https://github.com/prettier/plugin-pug/issues",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
Hi! I'm submitting this PR because in the [simple-icons](https://github.com/simple-icons/simple-icons) project we are trying to automate as much as possible our monetary contributions to our direct dependencies, so having this metadata in the package.json files allows us to programmatically know easily how we can fund them. See [package-json#funding](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#funding).

Cheers!