### PR TITLE
Don't auto-load prettier-plugin-organize-imports in tests

### DIFF
--- a/tests/common.ts
+++ b/tests/common.ts
@@ -97,7 +97,7 @@ export function compareFiles(
   const actual: string = format(code, {
     parser: 'pug',
     plugins: [plugin],
-    pluginSearchDirs: false,
+    // pluginSearchDirs: false,
     ...formatOptions,
   });
 

--- a/tests/common.ts
+++ b/tests/common.ts
@@ -97,6 +97,7 @@ export function compareFiles(
   const actual: string = format(code, {
     parser: 'pug',
     plugins: [plugin],
+    pluginSearchDirs: false,
     ...formatOptions,
   });
 

--- a/tests/issues/issue-419/formatted.pug
+++ b/tests/issues/issue-419/formatted.pug
@@ -1,0 +1,4 @@
+.topic(
+  v-for="topic in topics",
+  v-delayed-unhide="{ disabled: !!selectedTopic }"
+)

--- a/tests/issues/issue-419/issue-419.test.ts
+++ b/tests/issues/issue-419/issue-419.test.ts
@@ -1,0 +1,38 @@
+import { compareFiles } from 'tests/common';
+import type { SpyInstance } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('Issues', () => {
+  it('should log a warning when passing inline object literal to custom vue directive and pugFramework is not set', () => {
+    const spyConsoleWarn: SpyInstance<
+      [message?: any, ...optionalParams: any[]],
+      void
+    > = vi.spyOn(console, 'warn');
+
+    const { expected, actual } = compareFiles(__dirname);
+    expect(actual).toBe(expected);
+
+    expect(spyConsoleWarn).toHaveBeenCalledWith(
+      'The following expression could not be formatted correctly. Please try to fix it yourself and if there is a problem, please open a bug issue:',
+      'disabled: !!selectedTopic',
+    );
+
+    spyConsoleWarn.mockRestore();
+  });
+
+  it('should not log a warning when passing inline object literal to custom vue directive and pugFramework is set to vue', () => {
+    const spyConsoleWarn: SpyInstance<
+      [message?: any, ...optionalParams: any[]],
+      void
+    > = vi.spyOn(console, 'warn');
+
+    const { expected, actual } = compareFiles(__dirname, {
+      formatOptions: { pugFramework: 'vue' },
+    });
+    expect(actual).toBe(expected);
+
+    expect(spyConsoleWarn).not.toHaveBeenCalled();
+
+    spyConsoleWarn.mockRestore();
+  });
+});

--- a/tests/issues/issue-419/unformatted.pug
+++ b/tests/issues/issue-419/unformatted.pug
@@ -1,0 +1,4 @@
+.topic(
+  v-for="topic in topics"
+  v-delayed-unhide="{ disabled: !!selectedTopic }"
+)


### PR DESCRIPTION
I noticed this during debugging #419:

The `prettier-plugin-organize-imports` plugin gets auto-loaded in the unit tests, and it has side-effects that effect the parsers. To make sure we really only test this plugin and exclude such side-effects, we should pass `pluginSearchDirs: false` to the `formatOptions` by default.