### PR TITLE
Add semi code interpolation option

### DIFF
--- a/src/printer.ts
+++ b/src/printer.ts
@@ -197,7 +197,7 @@ export class PugPrinter {
 
   private readonly codeInterpolationOptions: Pick<
     RequiredOptions,
-    | 'semi',
+    | 'semi'
     | 'singleQuote'
     | 'bracketSpacing'
     | 'arrowParens'

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -197,6 +197,7 @@ export class PugPrinter {
 
   private readonly codeInterpolationOptions: Pick<
     RequiredOptions,
+    | 'semi',
     | 'singleQuote'
     | 'bracketSpacing'
     | 'arrowParens'

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -261,6 +261,7 @@ export class PugPrinter {
       : null;
 
     this.codeInterpolationOptions = {
+      semi: options.pugSemi ?? options.semi,
       singleQuote: options.pugSingleQuote ?? options.singleQuote,
       bracketSpacing: options.pugBracketSpacing ?? options.bracketSpacing,
       arrowParens: options.pugArrowParens ?? options.arrowParens,


### PR DESCRIPTION
Interpolated code currently does not respect the *semi* option.

With `semi: false`

Before this change
```js
script.
  console.log("test");
```

After this change
```js
script.
  console.log("test")
```