### PR TITLE
Fix class attributes not counting towards attribute wrapping

### DIFF
--- a/src/printer.ts
+++ b/src/printer.ts
@@ -829,10 +829,12 @@ export class PugPrinter {
         switch (tempToken.name) {
           case 'class':
           case 'id': {
-            // If classes are defined as attributes and not converted to literals, count them toward attribute wrapping.
+            // If classes or IDs are defined as attributes and not converted to literals, count them toward attribute wrapping.
             if (
-              tempToken.name === 'class' &&
-              this.options.pugClassNotation !== 'literal'
+              (tempToken.name === 'class' &&
+                this.options.pugClassNotation !== 'literal') ||
+              (tempToken.name === 'id' &&
+                this.options.pugIdNotation !== 'literal')
             ) {
               numNormalAttributes++;
             }

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -827,6 +827,13 @@ export class PugPrinter {
         switch (tempToken.name) {
           case 'class':
           case 'id': {
+            // If classes are forced as attributes, count them toward attribute wrapping.
+            if (
+              tempToken.name === 'class' &&
+              this.options.pugClassNotation !== 'literal'
+            ) {
+              numNormalAttributes++;
+            }
             hasLiteralAttributes = true;
             const val: string = tempToken.val.toString();
             if (isQuoted(val)) {

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -827,7 +827,7 @@ export class PugPrinter {
         switch (tempToken.name) {
           case 'class':
           case 'id': {
-            // If classes are forced as attributes, count them toward attribute wrapping.
+            // If classes are defined as attributes and not converted to literals, count them toward attribute wrapping.
             if (
               tempToken.name === 'class' &&
               this.options.pugClassNotation !== 'literal'

--- a/tests/options/pugWrapAttributesThreshold/withAsIsClassNotation/formatted.pug
+++ b/tests/options/pugWrapAttributesThreshold/withAsIsClassNotation/formatted.pug
@@ -1,0 +1,10 @@
+div(class="class")
+div(
+  class="class",
+  attribute="value"
+)
+.class(attribute="value")
+.class(
+  attribute="value",
+  another-attribute="another value"
+)

--- a/tests/options/pugWrapAttributesThreshold/withAsIsClassNotation/unformatted.pug
+++ b/tests/options/pugWrapAttributesThreshold/withAsIsClassNotation/unformatted.pug
@@ -1,0 +1,4 @@
+div(class="class")
+div(class="class" attribute="value")
+div.class(attribute="value")
+div.class(attribute="value" another-attribute="another value")

--- a/tests/options/pugWrapAttributesThreshold/withAsIsClassNotation/with-as-is-class-notation.test.ts
+++ b/tests/options/pugWrapAttributesThreshold/withAsIsClassNotation/with-as-is-class-notation.test.ts
@@ -1,0 +1,17 @@
+import { compareFiles } from 'tests/common';
+import { describe, expect, it } from 'vitest';
+
+describe('Options', () => {
+  describe('pugWrapAttributesThreshold', () => {
+    it('should count classes as attributes if pugClassNotation === as-is', async () => {
+      const { actual, expected } = await compareFiles(import.meta.url, {
+        formatOptions: {
+          pugWrapAttributesThreshold: 1,
+          pugClassNotation: 'as-is',
+        },
+      });
+
+      expect(actual).toBe(expected);
+    });
+  });
+});

--- a/tests/options/pugWrapAttributesThreshold/withAsIsClassNotation/with-as-is-class-notation.test.ts
+++ b/tests/options/pugWrapAttributesThreshold/withAsIsClassNotation/with-as-is-class-notation.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 describe('Options', () => {
   describe('pugWrapAttributesThreshold', () => {
-    it('should count classes as attributes if pugClassNotation === as-is', async () => {
+    it('should count attribute classes toward wrapping if pugClassNotation === as-is', async () => {
       const { actual, expected } = await compareFiles(import.meta.url, {
         formatOptions: {
           pugWrapAttributesThreshold: 1,

--- a/tests/options/pugWrapAttributesThreshold/withAsIsIdNotation/formatted.pug
+++ b/tests/options/pugWrapAttributesThreshold/withAsIsIdNotation/formatted.pug
@@ -1,0 +1,10 @@
+div(id="foo")
+div(
+  id="foo",
+  attribute="value"
+)
+#foo(attribute="value")
+#foo(
+  attribute="value",
+  another-attribute="another value"
+)

--- a/tests/options/pugWrapAttributesThreshold/withAsIsIdNotation/unformatted.pug
+++ b/tests/options/pugWrapAttributesThreshold/withAsIsIdNotation/unformatted.pug
@@ -1,0 +1,4 @@
+div(id="foo")
+div(id="foo" attribute="value")
+div#foo(attribute="value")
+div#foo(attribute="value" another-attribute="another value")

--- a/tests/options/pugWrapAttributesThreshold/withAsIsIdNotation/with-as-is-id-notation.test.ts
+++ b/tests/options/pugWrapAttributesThreshold/withAsIsIdNotation/with-as-is-id-notation.test.ts
@@ -1,0 +1,17 @@
+import { compareFiles } from 'tests/common';
+import { describe, expect, it } from 'vitest';
+
+describe('Options', () => {
+  describe('pugWrapAttributesThreshold', () => {
+    it('should count attribute IDs toward wrapping if pugIdNotation === as-is', async () => {
+      const { actual, expected } = await compareFiles(import.meta.url, {
+        formatOptions: {
+          pugWrapAttributesThreshold: 1,
+          pugIdNotation: 'as-is',
+        },
+      });
+
+      expect(actual).toBe(expected);
+    });
+  });
+});

--- a/tests/options/pugWrapAttributesThreshold/withAttributeClassNotation/formatted.pug
+++ b/tests/options/pugWrapAttributesThreshold/withAttributeClassNotation/formatted.pug
@@ -1,0 +1,5 @@
+div(class="class")
+div(
+  class="class",
+  attribute="value"
+)

--- a/tests/options/pugWrapAttributesThreshold/withAttributeClassNotation/unformatted.pug
+++ b/tests/options/pugWrapAttributesThreshold/withAttributeClassNotation/unformatted.pug
@@ -1,0 +1,2 @@
+div(class="class")
+div(class="class" attribute="value")

--- a/tests/options/pugWrapAttributesThreshold/withAttributeClassNotation/with-attribute-class-notation.test.ts
+++ b/tests/options/pugWrapAttributesThreshold/withAttributeClassNotation/with-attribute-class-notation.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 describe('Options', () => {
   describe('pugWrapAttributesThreshold', () => {
-    it('should count classes as attributes if pugClassNotation === attribute', async () => {
+    it('should count attribute classes toward wrapping if pugClassNotation === attribute', async () => {
       const { actual, expected } = await compareFiles(import.meta.url, {
         formatOptions: {
           pugWrapAttributesThreshold: 1,

--- a/tests/options/pugWrapAttributesThreshold/withAttributeClassNotation/with-attribute-class-notation.test.ts
+++ b/tests/options/pugWrapAttributesThreshold/withAttributeClassNotation/with-attribute-class-notation.test.ts
@@ -1,0 +1,17 @@
+import { compareFiles } from 'tests/common';
+import { describe, expect, it } from 'vitest';
+
+describe('Options', () => {
+  describe('pugWrapAttributesThreshold', () => {
+    it('should count classes as attributes if pugClassNotation === attribute', async () => {
+      const { actual, expected } = await compareFiles(import.meta.url, {
+        formatOptions: {
+          pugWrapAttributesThreshold: 1,
+          pugClassNotation: 'attribute',
+        },
+      });
+
+      expect(actual).toBe(expected);
+    });
+  });
+});


### PR DESCRIPTION
### Issue

There are a few issues with the `pugClassNotation: 'attribute'` option that resolve themselves with multiple repeated runs (one run to convert from literals to attributes with broken formatting, another run to fix the formatting) but one issue persists.

Classes are not counted to `numNormalAttributes` when deciding if the attributes should be wrapped as per `pugWrapAttributesThreshold`. This causes lines not to wrap as expected if they have class attributes.

Input with `pugWrapAttributesThreshold: 1` and `pugClassNotation: 'attribute'`:

```pug
div(class="class" attribute="value")
```

Output:

```pug
// Still on one line (bad)
div(class="class" attribute="value")
```

Expected output:

```pug
div(
  class="class",
  attribute="value"
)
```

### Fix

I added an extra check to the code path for classes that manually adds +1 to `numNormalAttributes` if classes were defined as attributes and they are not explicitly forced to be converted to literals.

### Test

I added two new tests (better naming welcome) demonstrating correct wrapping when both `pugClassNotation` and `pugWrapAttributesThreshold` have been set. I left the tests simple as more complex setups like mixed literal + attribute classes will hit formatting bugs that should not be in the scope of this PR.