### PR TITLE
Multiple fixes for class attribute conversions

### DIFF
--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1277,12 +1277,15 @@ export class PugPrinter {
 
       // An extra div should be printed if...
       if (
+        this.previousToken === undefined ||
         // ...the previous token indicates that this was the first class literal and thus a div did not previously exist...
-        (this.previousToken?.type !== 'tag' &&
-          this.previousToken?.type !== 'class' &&
-          this.previousToken?.type !== 'end-attributes') ||
+        this.checkTokenType(
+          this.previousToken,
+          ['tag', 'class', 'end-attributes'],
+          true,
+        ) ||
         // ...OR the previous token is a div that will be removed because of the no explicit divs rule.
-        (this.previousToken?.type === 'tag' &&
+        (this.previousToken.type === 'tag' &&
           this.previousToken.val === 'div' &&
           this.nextToken?.type !== 'attribute' &&
           !this.options.pugExplicitDiv)
@@ -1291,10 +1294,14 @@ export class PugPrinter {
       }
 
       if (
-        this.nextToken &&
-        ['text', 'newline', 'indent', 'outdent', 'eos', ':'].includes(
-          this.nextToken.type,
-        )
+        this.checkTokenType(this.nextToken, [
+          'text',
+          'newline',
+          'indent',
+          'outdent',
+          'eos',
+          ':',
+        ])
       ) {
         // Copy and clear the class literals list.
         const classes: string[] = this.classLiteralToAttribute.splice(
@@ -1333,7 +1340,7 @@ export class PugPrinter {
           this.result += `(class=${this.quoteString(classes.join(' '))})`;
         }
 
-        if (this.nextToken.type === 'text') {
+        if (this.nextToken?.type === 'text') {
           this.result += ' ';
         }
       }

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1290,24 +1290,6 @@ export class PugPrinter {
         this.result += `${this.computedIndent}div`;
       }
 
-      // If last token was the end of attributes...
-      // if (this.previousToken?.type === 'end-attributes') {
-      //   // ...and the attributes contained a class attribute...
-      //   const lastClassIndex: number = this.tokens
-      //     .slice(0, this.currentIndex)
-      //     .findIndex((t) => t.type === 'attribute' && t.name === 'class');
-
-      //   if (lastClassIndex > -1) {
-      //     // ...then find the last class attribute and insert the new class into it.
-      //     const position: number = this.result.lastIndexOf('class=') + 7;
-      //     this.result = [
-      //       this.result.slice(0, position),
-      //       `${token.val} `,
-      //       this.result.slice(position),
-      //     ].join('');
-      //   }
-      // }
-
       if (
         this.nextToken &&
         ['text', 'newline', 'indent', 'outdent', 'eos', ':'].includes(

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1271,6 +1271,14 @@ export class PugPrinter {
     return result;
   }
 
+  /**
+   * Processes the class token and appends the class name to the result.
+   * 
+   * This method handles the class token by either converting it to an attribute
+   * or appending it directly to the result based on the `pugClassNotation` option.
+   * 
+   * @param token - The class token to process.
+   */
   private class(token: ClassToken): void {
     if (this.options.pugClassNotation === 'attribute') {
       this.classLiteralToAttribute.push(token.val);

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1271,33 +1271,38 @@ export class PugPrinter {
     return result;
   }
 
-  /**
-   * Processes the class token and appends the class name to the result.
-   * 
-   * This method handles the class token by either converting it to an attribute
-   * or appending it directly to the result based on the `pugClassNotation` option.
-   * 
-   * @param token - The class token to process.
-   */
   private class(token: ClassToken): void {
     if (this.options.pugClassNotation === 'attribute') {
       this.classLiteralToAttribute.push(token.val);
+
+      // An extra div should be printed if...
       if (
-        this.previousToken?.type !== 'tag' &&
-        this.previousToken?.type !== 'class'
+        // ...the previous token indicates that this was the first class literal and thus a div did not previously exist...
+        (this.previousToken?.type !== 'tag' &&
+          this.previousToken?.type !== 'class' &&
+          this.previousToken?.type !== 'end-attributes') ||
+        // ...OR the previous token is a div that will be removed because of the no explicit divs rule.
+        (this.previousToken?.type === 'tag' &&
+          this.previousToken.val === 'div' &&
+          this.nextToken?.type !== 'attribute' &&
+          !this.options.pugExplicitDiv)
       ) {
         this.result += `${this.computedIndent}div`;
       }
+
       if (
         this.nextToken &&
-        ['text', 'newline', 'indent', 'outdent', 'eos'].includes(
+        ['text', 'newline', 'indent', 'outdent', 'eos', ':'].includes(
           this.nextToken.type,
         )
       ) {
+        // Copy and clear the class literals list.
         const classes: string[] = this.classLiteralToAttribute.splice(
           0,
           this.classLiteralToAttribute.length,
         );
+
+        // TODO: This does not work if we have already passed the end of the attributes. What to do?
         this.result += `(class=${this.quoteString(classes.join(' '))})`;
         if (this.nextToken.type === 'text') {
           this.result += ' ';

--- a/tests/options/pugClassNotation/formatted-as-is.pug
+++ b/tests/options/pugClassNotation/formatted-as-is.pug
@@ -25,3 +25,31 @@ div: span.foo
 div: span(class="foo")
 .foo: span.bar.foo(class="baz")
 .foo.baz(class="bar"): h1.foo.baz(class="bar") Let's really #[span.foo.baz(class="bar") get nasty]!
+.indent
+  input.bar.baz(class="foo")
+  input.bar.baz(
+    readonly,
+    class="foo",
+    name="test-input",
+    type="password",
+    value="Hello World"
+  )
+  .foo bar
+  .foo(bar="baz") Hello World
+  .foo
+    div(class="bar") baz
+  .baz
+  .bar foo
+  - var code = "ma-2 px-1";
+  div(class=code)
+  .foo
+  div.foo(attribute="value")
+  div.foo(class="bar", attribute="value")
+  div.foo.baz(attribute="value", class="bar")
+  div.foo.baz(attribute="value", class="bar")
+  .foo.baz(attribute="value", class="bar")
+  div.bar(class="foo"): span Text
+  div: span.foo
+  div: span(class="foo")
+  .foo: span.bar.foo(class="baz")
+  .foo.baz(class="bar"): h1.foo.baz(class="bar") Let's really #[span.foo.baz(class="bar") get nasty]!

--- a/tests/options/pugClassNotation/formatted-as-is.pug
+++ b/tests/options/pugClassNotation/formatted-as-is.pug
@@ -20,6 +20,7 @@ div.foo(class="bar", attribute="value")
 div.foo.baz(attribute="value", class="bar")
 div.foo.baz(attribute="value", class="bar")
 .foo.baz(attribute="value", class="bar")
+div.bar(class="foo"): span Text
 div: span.foo
 div: span(class="foo")
 .foo: span.bar.foo(class="baz")

--- a/tests/options/pugClassNotation/formatted-as-is.pug
+++ b/tests/options/pugClassNotation/formatted-as-is.pug
@@ -1,0 +1,26 @@
+input.bar.baz(class="foo")
+input.bar.baz(
+  readonly,
+  class="foo",
+  name="test-input",
+  type="password",
+  value="Hello World"
+)
+.foo bar
+.foo(bar="baz") Hello World
+.foo
+  div(class="bar") baz
+.baz
+.bar foo
+- var code = "ma-2 px-1";
+div(class=code)
+.foo
+div.foo(attribute="value")
+div.foo(class="bar", attribute="value")
+div.foo.baz(attribute="value", class="bar")
+div.foo.baz(attribute="value", class="bar")
+.foo.baz(attribute="value", class="bar")
+div: span.foo
+div: span(class="foo")
+.foo: span.bar.foo(class="baz")
+.foo.baz(class="bar"): h1.foo.baz(class="bar") Let's really #[span.foo.baz(class="bar") get nasty]!

--- a/tests/options/pugClassNotation/formatted-attribute.pug
+++ b/tests/options/pugClassNotation/formatted-attribute.pug
@@ -10,11 +10,11 @@ div(class="bar") foo
 div(class=code)
 div(class="foo")
 div(attribute="value", class="foo")
-div(attribute="value")
 div(attribute="value", class="bar foo")
 div(attribute="value", class="bar foo baz")
 div(attribute="value", class="bar foo baz")
 div(attribute="value", class="bar foo baz")
+div(class="foo bar"): span Text
 div: span(class="foo")
 div: span(class="foo")
 div(class="foo"): span(class="bar baz foo")

--- a/tests/options/pugClassNotation/formatted-attribute.pug
+++ b/tests/options/pugClassNotation/formatted-attribute.pug
@@ -19,3 +19,25 @@ div: span(class="foo")
 div: span(class="foo")
 div(class="foo"): span(class="foo bar baz")
 div(class="baz foo bar"): h1(class="baz foo bar") Let's really #[span(class="baz foo bar") get nasty]!
+div(class="indent")
+  input(class="bar baz foo")
+  input(readonly, class="bar baz foo", name="test-input", type="password", value="Hello World")
+  div(class="foo") bar
+  div(bar="baz" class="foo") Hello World
+  div(class="foo")
+    div(class="bar") baz
+  div(class="baz")
+  div(class="bar") foo
+  - var code = "ma-2 px-1";
+  div(class=code)
+  div(class="foo")
+  div(attribute="value", class="foo")
+  div(class="foo bar", attribute="value")
+  div(attribute="value", class="foo baz bar")
+  div(attribute="value", class="foo baz bar")
+  div(attribute="value", class="baz foo bar")
+  div(class="bar foo"): span Text
+  div: span(class="foo")
+  div: span(class="foo")
+  div(class="foo"): span(class="foo bar baz")
+  div(class="baz foo bar"): h1(class="baz foo bar") Let's really #[span(class="baz foo bar") get nasty]!

--- a/tests/options/pugClassNotation/formatted-attribute.pug
+++ b/tests/options/pugClassNotation/formatted-attribute.pug
@@ -10,12 +10,12 @@ div(class="bar") foo
 div(class=code)
 div(class="foo")
 div(attribute="value", class="foo")
-div(attribute="value", class="bar foo")
-div(attribute="value", class="bar foo baz")
-div(attribute="value", class="bar foo baz")
-div(attribute="value", class="bar foo baz")
-div(class="foo bar"): span Text
+div(class="foo bar", attribute="value")
+div(attribute="value", class="foo baz bar")
+div(attribute="value", class="foo baz bar")
+div(attribute="value", class="baz foo bar")
+div(class="bar foo"): span Text
 div: span(class="foo")
 div: span(class="foo")
-div(class="foo"): span(class="bar baz foo")
-div(class="foo bar baz"): h1(class="foo bar baz") Let's really #[span(class="foo bar baz") get nasty]!
+div(class="foo"): span(class="foo bar baz")
+div(class="baz foo bar"): h1(class="baz foo bar") Let's really #[span(class="baz foo bar") get nasty]!

--- a/tests/options/pugClassNotation/formatted-attribute.pug
+++ b/tests/options/pugClassNotation/formatted-attribute.pug
@@ -8,3 +8,14 @@ div(class="baz")
 div(class="bar") foo
 - var code = "ma-2 px-1";
 div(class=code)
+div(class="foo")
+div(attribute="value", class="foo")
+div(attribute="value")
+div(attribute="value", class="bar foo")
+div(attribute="value", class="bar foo baz")
+div(attribute="value", class="bar foo baz")
+div(attribute="value", class="bar foo baz")
+div: span(class="foo")
+div: span(class="foo")
+div(class="foo"): span(class="bar baz foo")
+div(class="foo bar baz"): h1(class="foo bar baz") Let's really #[span(class="foo bar baz") get nasty]!

--- a/tests/options/pugClassNotation/formatted-literal.pug
+++ b/tests/options/pugClassNotation/formatted-literal.pug
@@ -24,3 +24,30 @@ div: span.foo
 div: span.foo
 .foo: span.bar.baz.foo
 .foo.bar.baz: h1.foo.bar.baz Let's really #[span.foo.bar.baz get nasty]!
+.indent
+  input.bar.baz.foo
+  input.bar.baz.foo(
+    readonly,
+    name="test-input",
+    type="password",
+    value="Hello World"
+  )
+  .foo bar
+  .foo(bar="baz") Hello World
+  .foo
+    .bar baz
+  .baz
+  .bar foo
+  - var code = "ma-2 px-1";
+  div(class=code)
+  .foo
+  div.foo(attribute="value")
+  .bar.foo(attribute="value")
+  .bar.foo.baz(attribute="value")
+  .bar.foo.baz(attribute="value")
+  .foo.bar.baz(attribute="value")
+  .foo.bar: span Text
+  div: span.foo
+  div: span.foo
+  .foo: span.bar.baz.foo
+  .foo.bar.baz: h1.foo.bar.baz Let's really #[span.foo.bar.baz get nasty]!

--- a/tests/options/pugClassNotation/formatted-literal.pug
+++ b/tests/options/pugClassNotation/formatted-literal.pug
@@ -19,6 +19,7 @@ div.foo(attribute="value")
 .bar.foo.baz(attribute="value")
 .bar.foo.baz(attribute="value")
 .foo.bar.baz(attribute="value")
+.foo.bar: span Text
 div: span.foo
 div: span.foo
 .foo: span.bar.baz.foo

--- a/tests/options/pugClassNotation/formatted-literal.pug
+++ b/tests/options/pugClassNotation/formatted-literal.pug
@@ -13,3 +13,13 @@ input.bar.baz.foo(
 .bar foo
 - var code = "ma-2 px-1";
 div(class=code)
+.foo
+div.foo(attribute="value")
+.bar.foo(attribute="value")
+.bar.foo.baz(attribute="value")
+.bar.foo.baz(attribute="value")
+.foo.bar.baz(attribute="value")
+div: span.foo
+div: span.foo
+.foo: span.bar.baz.foo
+.foo.bar.baz: h1.foo.bar.baz Let's really #[span.foo.bar.baz get nasty]!

--- a/tests/options/pugClassNotation/pug-class-notation.test.ts
+++ b/tests/options/pugClassNotation/pug-class-notation.test.ts
@@ -4,13 +4,13 @@ import { describe, expect, it } from 'vitest';
 describe('Options', () => {
   describe('pugClassNotation', () => {
     it('should keep classes as is', async () => {
-      const { actual, code } = await compareFiles(import.meta.url, {
-        target: null,
+      const { actual, expected } = await compareFiles(import.meta.url, {
+        target: 'formatted-as-is.pug',
         formatOptions: {
           pugClassNotation: 'as-is',
         },
       });
-      expect(actual).toBe(code);
+      expect(actual).toBe(expected);
     });
 
     it('should keep classes as literals', async () => {

--- a/tests/options/pugClassNotation/unformatted.pug
+++ b/tests/options/pugClassNotation/unformatted.pug
@@ -28,3 +28,34 @@ div: span.foo
 div: span(class="foo")
 div.foo: span.bar(class="baz").foo
 div.foo(class="bar").baz: h1.foo(class="bar").baz Let's really #[span.foo(class="bar").baz get nasty]!
+.indent
+  input.bar.baz(class="foo")
+  input.bar.baz(
+    readonly,
+    class="foo",
+    name="test-input",
+    type="password",
+    value="Hello World"
+  )
+  .foo bar
+  .foo(bar="baz") Hello World
+  .foo
+    div(class="bar") baz
+  .baz
+  .bar foo
+  - var code = "ma-2 px-1";
+  div(class=code)
+  div.foo
+  div(attribute="value").foo
+  div(class="bar", attribute="value").foo
+  div(attribute="value", class="bar").foo.baz
+  div(
+    attribute="value"
+    class="bar"
+  ).foo.baz
+  div.foo(attribute="value" class="bar").baz
+  div(class="foo").bar: span Text
+  div: span.foo
+  div: span(class="foo")
+  div.foo: span.bar(class="baz").foo
+  div.foo(class="bar").baz: h1.foo(class="bar").baz Let's really #[span.foo(class="bar").baz get nasty]!

--- a/tests/options/pugClassNotation/unformatted.pug
+++ b/tests/options/pugClassNotation/unformatted.pug
@@ -16,8 +16,8 @@ input.bar.baz(
 div(class=code)
 div.foo
 div(attribute="value").foo
-div(attribute="value" class="bar").foo
-div(attribute="value" class="bar").foo.baz
+div(class="bar", attribute="value").foo
+div(attribute="value", class="bar").foo.baz
 div(
   attribute="value"
   class="bar"

--- a/tests/options/pugClassNotation/unformatted.pug
+++ b/tests/options/pugClassNotation/unformatted.pug
@@ -23,6 +23,7 @@ div(
   class="bar"
 ).foo.baz
 div.foo(attribute="value" class="bar").baz
+div(class="foo").bar: span Text
 div: span.foo
 div: span(class="foo")
 div.foo: span.bar(class="baz").foo

--- a/tests/options/pugClassNotation/unformatted.pug
+++ b/tests/options/pugClassNotation/unformatted.pug
@@ -14,3 +14,16 @@ input.bar.baz(
 .bar foo
 - var code = "ma-2 px-1";
 div(class=code)
+div.foo
+div(attribute="value").foo
+div(attribute="value" class="bar").foo
+div(attribute="value" class="bar").foo.baz
+div(
+  attribute="value"
+  class="bar"
+).foo.baz
+div.foo(attribute="value" class="bar").baz
+div: span.foo
+div: span(class="foo")
+div.foo: span.bar(class="baz").foo
+div.foo(class="bar").baz: h1.foo(class="bar").baz Let's really #[span.foo(class="bar").baz get nasty]!


### PR DESCRIPTION
Closes #508 

This PR adds tests and fixes for previously untested variations of class literals in increasingly complex scenarios. Most of them output non-valid Pug code currently.

I fixed all the new test cases to output valid Pug code without regressions, so this is probably safe to merge. I don't have full confidence that there are no other (currently untested) bad combinations of the various options, but this is for sure better than before.

Examples of code that previously outputted invalid Pug but now work:

```pug
// Class literals at the end of attributes did not work.
div(attribute="value").foo
div(class="bar", attribute="value").foo
div(attribute="value", class="bar").foo.baz
div(
  attribute="value"
  class="bar"
).foo.baz
div.foo(attribute="value" class="bar").baz

// Class literals ending at : did not work
div(class="foo").bar: span Text
div: span.foo
div: span(class="foo")
div.foo: span.bar(class="baz").foo

// Class literals in an interpolated line did not work
div.foo(class="bar").baz: h1.foo(class="bar").baz Let's really #[span.foo(class="bar").baz get nasty]!
```