### PR TITLE
Handle else blocks and comments in unbuffered code

### DIFF
--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1882,6 +1882,7 @@ export class PugPrinter {
       }
     }
   }
+
   // Since every line is parsed independently, babel will throw a SyntaxError if the line of code is only valid when there is another statement after it, or if the line starts with `else if` or `else`. This is a hack to get babel to properly parse what would otherwise be an invalid standalone JS line (e.g., `if (foo)`, `else if (bar)`, `else`)
   private async formatRawCodeWithFallback(
     val: string,
@@ -1889,13 +1890,13 @@ export class PugPrinter {
   ): Promise<string> {
     if (val.startsWith('else')) {
       // If the code starts with `else`, then we can format the code without the `else` keyword, and then add it back onto the start.
-      // We can call the same helper function so then we can easily handle both `if`, `else if`, and `else` cases without having to write out each one.
+      // We can call the same helper function in each case, just with different inputs, so we can easily handle all `if`, `else if`, and `else` cases without having to write out each one.
       const noElse: string = await this.formatRawCodeWithFallbackNoElse(
         val.slice(4),
         useSemi,
       );
-      // `noElse` will either be an empty string or it will contain a comment. Now we just prepend `else` onto the start and add a space if `noElse` has something in it
-      return 'else' + (noElse ? ` ${noElse}` : '');
+      // `noElse` will either be an empty string or it will contain a comment. Now we just prepend `else` onto the start and trim in case `noElse` is empty
+      return `else ${noElse}`.trim();
     } else {
       return await this.formatRawCodeWithFallbackNoElse(val, useSemi);
     }

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1823,24 +1823,12 @@ export class PugPrinter {
     return val.slice(0, -1);
   }
 
-  // Since every line is parsed independently, babel will throw a SyntaxError if the line of code is only valid when there is another statement after it, or if the line starts with `else if` or `else`. This is a hack to get babel to properly parse what would otherwise be an invalid standalone JS line (e.g., `if (foo)`, `else if (bar)`, `else`)
-  private async formatRawCodeWithFallback(
+  private async formatRawCodeWithFallbackNoElse(
     val: string,
     useSemi: boolean,
   ): Promise<string> {
     try {
-      if (val.startsWith('else')) {
-        // If the code starts with `else`, then we can format the code without the `else` keyword, and then add it back onto the start.
-        // We can call this function recursively since then we can easily handle `else if` cases without having to write a special case.
-        const noElse: string = await this.formatRawCodeWithFallback(
-          val.slice(4),
-          useSemi,
-        );
-        // `noElse` will either be an empty string or it will contain a comment. Now we just prepend `else` onto the start and add a space if `noElse` has something in it
-        return 'else' + (noElse ? ` ${noElse}` : '');
-      } else {
-        return await this.formatRawCode(val, useSemi);
-      }
+      return await this.formatRawCode(val, useSemi);
     } catch (error: unknown) {
       if (!(error instanceof SyntaxError)) throw error;
 
@@ -1892,6 +1880,24 @@ export class PugPrinter {
         // throw original error since our fallback didn't work
         throw error;
       }
+    }
+  }
+  // Since every line is parsed independently, babel will throw a SyntaxError if the line of code is only valid when there is another statement after it, or if the line starts with `else if` or `else`. This is a hack to get babel to properly parse what would otherwise be an invalid standalone JS line (e.g., `if (foo)`, `else if (bar)`, `else`)
+  private async formatRawCodeWithFallback(
+    val: string,
+    useSemi: boolean,
+  ): Promise<string> {
+    if (val.startsWith('else')) {
+      // If the code starts with `else`, then we can format the code without the `else` keyword, and then add it back onto the start.
+      // We can call the same helper function so then we can easily handle both `if`, `else if`, and `else` cases without having to write out each one.
+      const noElse: string = await this.formatRawCodeWithFallbackNoElse(
+        val.slice(4),
+        useSemi,
+      );
+      // `noElse` will either be an empty string or it will contain a comment. Now we just prepend `else` onto the start and add a space if `noElse` has something in it
+      return 'else' + (noElse ? ` ${noElse}` : '');
+    } else {
+      return await this.formatRawCodeWithFallbackNoElse(val, useSemi);
     }
   }
 

--- a/tests/unbuffered-code/formatted.pug
+++ b/tests/unbuffered-code/formatted.pug
@@ -12,6 +12,8 @@
   p #{ obj.color2 } is the second color, if it exists
 - else
   p Else without a comment
+- for (const k of obj?.items || []) // Comment
+  p #{ k }
 - for (const k of obj?.items || [])
   p #{ k }
 - let n = 2;

--- a/tests/unbuffered-code/formatted.pug
+++ b/tests/unbuffered-code/formatted.pug
@@ -1,5 +1,20 @@
-- if (obj?.name)
+- if (obj?.name) /* Block comment */
   p #{ obj.name } is the name, if it exists
+- if (obj?.name2) // Double-slash comment
+  p #{ obj.name2 } is the second name, if it exists
+- if (obj?.name3)
+  p #{ obj.name3 } is the third name, if it exists
+- else if (obj?.color) /* Comment */
+  p #{ obj.color } is the color, if it exists
+- else // Comment, plus the else has whitespace before it
+  p No name or color
+- if (obj?.color2)
+  p #{ obj.color2 } is the second color, if it exists
+- else
+  p Else without a comment
 - for (const k of obj?.items || [])
   p #{ k }
+- let n = 2;
+- while (n--) // Comment!
+  p #{ n }
 p This should always appear

--- a/tests/unbuffered-code/unbuffered-code.test.ts
+++ b/tests/unbuffered-code/unbuffered-code.test.ts
@@ -2,7 +2,7 @@ import { compareFiles } from 'tests/common';
 import { describe, expect, it } from 'vitest';
 
 describe('Unbuffered code', () => {
-  it('should handle JS statements where the isolated line is only parsable when there is another statement afterwards', async () => {
+  it('should handle JS statements where the isolated line is only parsable when there is another statement before/afterwards', async () => {
     const { expected, actual } = await compareFiles(import.meta.url);
     expect(actual).toBe(expected);
   });

--- a/tests/unbuffered-code/unformatted.pug
+++ b/tests/unbuffered-code/unformatted.pug
@@ -12,6 +12,8 @@
   p #{ obj.color2 } is the second color, if it exists
 -    else
   p Else without a comment
+- for (const k of        obj?.items         || [])    // Comment
+  p #{ k }
 - for (const k of        obj?.items         || [])
   p #{ k }
 - let n = 2;

--- a/tests/unbuffered-code/unformatted.pug
+++ b/tests/unbuffered-code/unformatted.pug
@@ -1,5 +1,20 @@
-- if (         obj?.name      )
+- if (         obj?.name      )      /* Block comment */
   p #{ obj.name } is the name, if it exists
+- if (         obj?.name2      )    // Double-slash comment
+  p #{ obj.name2 } is the second name, if it exists
+- if (         obj?.name3      )
+  p #{ obj.name3 } is the third name, if it exists
+- else if (   obj?.color   )   /* Comment */
+  p #{ obj.color } is the color, if it exists
+-       else     // Comment, plus the else has whitespace before it
+  p No name or color
+-  if (         obj?.color2      )
+  p #{ obj.color2 } is the second color, if it exists
+-    else
+  p Else without a comment
 - for (const k of        obj?.items         || [])
   p #{ k }
+- let n = 2;
+- while (   n--    )    // Comment!
+  p #{ n }
 p This should always appear


### PR DESCRIPTION
In #601, I missed a couple critical cases:
- `else` and `else if` statements, where the syntax error is actually at the start of the line, not the end
- Lines that have comments at the end  (e.g., `if (foo) // here, we're doing xyz`), since adding an empty block at the end would mean it'd be commented out if it's a `//` comment

@Shinigami92 hope you don't mind that I went straight for a PR instead of opening an issue first.